### PR TITLE
Adds remember property to signIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ const LoginButton = ({ authenticated, user, signIn }) => {
   const handleLogin = () => {
     const email = "sanctum@example.org";
     const password = "example";
+    const remember = true;
 
-    signIn(email, password)
+    signIn(email, password, remember)
       .then(() => window.alert("Signed in!"))
       .catch(() => window.alert("Incorrect email or password"));
   };
@@ -75,7 +76,7 @@ data and methods:
 |-|------------------------------------------------------------------------------------|
 | `user` | Object your API returns with user data |
 | `authenticated` | Boolean, or null if authentication has not yet been checked |
-| `signIn()` | Accepts `(email, password)`, returns a promise, resolves with the user data. |
+| `signIn()` | Accepts `(email, password, remember?)`, returns a promise, resolves with the user data. |
 | `signOut()` | Returns a promise |
 | `setUser()` | Accepts `(user, authenticated?)`, allows you to manually set the user object and optionally its authentication status (boolean). |
 | `checkAuthentication()` | Returns the authentication status. If it's null, it will ask the server and update `authenticated`. |

--- a/src/Sanctum.tsx
+++ b/src/Sanctum.tsx
@@ -39,7 +39,7 @@ class Sanctum extends React.Component<Props, State> {
     this.checkAuthentication = this.checkAuthentication.bind(this);
   }
 
-  signIn(email: string, password: string): Promise<{}> {
+  signIn(email: string, password: string, remember: boolean = false): Promise<{}> {
     const {
       api_url,
       csrf_cookie_route,
@@ -52,7 +52,7 @@ class Sanctum extends React.Component<Props, State> {
         // Get CSRF cookie.
         await axios.get(`${api_url}/${csrf_cookie_route}`);
         // Sign in.
-        await axios.post(`${api_url}/${signin_route}`, { email, password });
+        await axios.post(`${api_url}/${signin_route}`, { email, password, remember: remember ? remember : null });
         // When correct, get the user data.
         const { data } = await axios.get(`${api_url}/${user_object_route}`);
         this.setState({ user: data, authenticated: true });

--- a/src/SanctumContext.tsx
+++ b/src/SanctumContext.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 export interface ContextProps {
   user: null | any;
   authenticated: null | boolean;
-  signIn: (email: string, password: string) => Promise<{}>;
+  signIn: (email: string, password: string, remember?: boolean) => Promise<{}>;
   signOut: () => void;
   setUser: (user: object, authenticated?: boolean) => void;
   checkAuthentication: () => Promise<boolean>;


### PR DESCRIPTION
```js
remember: remember ? remember : null
```
is necessary, because Laravel passes the attempt to the guard like this:
```php
return $this->guard()->attempt(
    $this->credentials($request), $request->filled('remember')
);
``` 

according to https://laravel.com/docs/7.x/helpers#method-filled, `filled(false)` returns `true`. This line converts `false` to `null`.