### PR TITLE
ConfigProps export, Support for usernameKey and Hook generic support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+yarn.lock
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/src/Sanctum.tsx
+++ b/src/Sanctum.tsx
@@ -4,16 +4,19 @@ import SanctumContext from "./SanctumContext";
 
 axios.defaults.withCredentials = true;
 
+export interface ConfigProps {
+  apiUrl: string;
+  csrfCookieRoute: string;
+  signInRoute: string;
+  signOutRoute: string;
+  userObjectRoute: string;
+  twoFactorChallengeRoute?: string;
+  axiosInstance?: AxiosInstance;
+  usernameKey?: string;
+}
+
 interface Props {
-  config: {
-    apiUrl: string;
-    csrfCookieRoute: string;
-    signInRoute: string;
-    signOutRoute: string;
-    userObjectRoute: string;
-    twoFactorChallengeRoute?: string;
-    axiosInstance?: AxiosInstance;
-  };
+  config: ConfigProps
   checkOnInit?: boolean;
   children: React.ReactNode;
 }
@@ -43,11 +46,11 @@ const Sanctum: React.FC<Props> = ({ checkOnInit = true, config, children }) => {
   };
 
   const signIn = (
-    email: string,
+    username: string,
     password: string,
     remember: boolean = false
   ): Promise<{ twoFactor: boolean; signedIn: boolean; user?: {} }> => {
-    const { apiUrl, signInRoute } = config;
+    const { apiUrl, signInRoute, usernameKey } = config;
 
     return new Promise(async (resolve, reject) => {
       try {
@@ -58,7 +61,7 @@ const Sanctum: React.FC<Props> = ({ checkOnInit = true, config, children }) => {
         const { data: signInData } = await localAxiosInstance.post(
           `${apiUrl}/${signInRoute}`,
           {
-            email,
+            [usernameKey || 'email']: username,
             password,
             remember: remember ? true : null,
           },

--- a/src/SanctumContext.tsx
+++ b/src/SanctumContext.tsx
@@ -4,7 +4,7 @@ export interface ContextProps {
   user: null | any;
   authenticated: null | boolean;
   signIn: (
-    email: string,
+    username: string,
     password: string,
     remember?: boolean
   ) => Promise<{ twoFactor: boolean; signedIn: boolean }>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Sanctum from "./Sanctum";
+import Sanctum, { ConfigProps } from "./Sanctum";
 import withSanctum from "./withSanctum";
 import useSanctum from "./useSanctum";
 import SanctumContext from "./SanctumContext";
@@ -6,6 +6,7 @@ import WithSanctumProps from "./WithSanctumProps";
 import { ContextProps as SanctumContextProps } from "./SanctumContext";
 
 export {
+  ConfigProps,
   Sanctum,
   withSanctum,
   useSanctum,

--- a/src/useSanctum.ts
+++ b/src/useSanctum.ts
@@ -1,12 +1,15 @@
 import * as React from "react";
 
-import SanctumContext from "./SanctumContext";
+import SanctumContext, { ContextProps } from "./SanctumContext";
 
-const useSanctum = () => {
+interface useSanctumReturn<T> extends ContextProps {
+  user: T;
+}
+
+export default function useSanctum<T = null | any>(): useSanctumReturn<T> {
   const context = React.useContext(SanctumContext);
   if (!context)
     throw new Error("useSanctum should only be used inside <Sanctum />");
   return context;
 };
 
-export default useSanctum;


### PR DESCRIPTION
The title rather explains it, it now exports the ``ConfigProps`` so they can be imported as a type for config reasons, and added support for a ``usernameKey`` that defaults to ``email`` if empty for logins that use something different than email.