### PR TITLE
Get revalidate config outside of promise

### DIFF
--- a/src/Sanctum.tsx
+++ b/src/Sanctum.tsx
@@ -131,9 +131,9 @@ const Sanctum: React.FC<Props> = ({ checkOnInit = true, config, children }) => {
   };
 
   const revalidate = (): Promise<boolean | { user: {} }> => {
+    const { apiUrl, userObjectRoute } = config;
+    
     return new Promise(async (resolve, reject) => {
-      const { apiUrl, userObjectRoute } = config;
-
       try {
         const { data } = await localAxiosInstance.get(
           `${apiUrl}/${userObjectRoute}`,


### PR DESCRIPTION
### Description
We have encountered an intermittent issue where `userObjectRoute` api was not defined when calling the `signIn` function.
Which would cause the `signIn` function to error but attempting login again immediately after would work. 

1. `signInRoute` successfully authenticates and logs in
2. `revalidate` is called which uses `userObjectRoute` and 9/10 times it calls the correct url
3. On the occasion where for some reason `userObjectRoute` is empty and we end up with it just calling `apiUrl` on its own:
![Screenshot 2022-09-13 at 18 05 10](https://user-images.githubusercontent.com/20278756/189964330-d13765df-dd3c-41dc-b755-4929157b25ac.png)

_Note: each request is duplicated above as it includes the cors OPTIONS request in the screenshot. This is normal behaviour._


### Solution
After looking at the code for this package I found the inconsistency with getting the config values in the `revalidate` function.

**_In every other function you extract the required config values from outside the returned promise._**

 I am not 100% certain that this solves the problem I have outlined above, but it could be the possible cause. 

### Config
```js
{
    apiUrl: Config.BASE_URI,
    csrfCookieRoute: 'api/auth/csrf',
    signInRoute: 'api/auth/login',
    signOutRoute: 'api/auth/logout',
    userObjectRoute: 'api/auth/check',
    axiosInstance: axios.create({
        withCredentials: true,
        mode: 'cors',
        headers: {
            Accept: 'application/json',
            'Content-Type': 'application/json',
            [Config.API_VERSION_HEADER]: Config.API_VERSION,
            'x-platform': process.env.target,
        },
        params: {
            referral_code: getReferralCodeCookie(),
            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
            locale: Intl.DateTimeFormat().resolvedOptions().locale,
        },
    }),
}
```